### PR TITLE
Cpu registers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .gradle
+.idea

--- a/src/main/kotlin/com/leeturner/spektrum/cpu/Registers.kt
+++ b/src/main/kotlin/com/leeturner/spektrum/cpu/Registers.kt
@@ -1,0 +1,64 @@
+package com.leeturner.spektrum.cpu
+
+/**
+ * Based on the Zilog Z80 CPU User Manual available here:
+ * https://www.zilog.com/docs/z80/um0080.pdf
+ */
+data class Registers(
+    // Special purpose registers
+    var programCounter: UShort = 0u,
+    var stackPointer: UShort = 0u,
+    var indexX: UShort = 0u,
+    var indexY: UShort = 0u,
+    var interruptPageAddress: UByte = 0u,
+    var memoryRefresh: UByte = 0u,
+
+    /**
+     * The CPU can switch between two sets of these registers using exchange instructions.
+     * There is a separate exchange instruction for the accumulatorAndFlag registers and the generalPurpose registers
+     */
+    private var accumulatorAndFlagRegisterSetIndex: Int = 0,
+    private val accumulatorAndFlagRegisterSets: List<AccumulatorAndFlagRegisterSet> =
+        listOf(AccumulatorAndFlagRegisterSet(), AccumulatorAndFlagRegisterSet()),
+
+    private var generalPurposeRegisterSetIndex: Int = 0,
+    private val generalPurposeRegisterSets: List<GeneralPurposeRegisterSet> =
+        listOf(GeneralPurposeRegisterSet(), GeneralPurposeRegisterSet())
+) {
+    fun flipAccumulatorAndFlagRegisterSet(): AccumulatorAndFlagRegisterSet {
+        accumulatorAndFlagRegisterSetIndex++
+        accumulatorAndFlagRegisterSetIndex %= 2
+
+        return accumulatorAndFlagRegisterSets[accumulatorAndFlagRegisterSetIndex]
+    }
+
+    fun flipGeneralPurposeRegisterSet(): GeneralPurposeRegisterSet {
+        generalPurposeRegisterSetIndex++
+        generalPurposeRegisterSetIndex %= 2
+
+        return generalPurposeRegisterSets[generalPurposeRegisterSetIndex]
+    }
+
+    fun getAccumulatorAndFlagRegisterSet() : AccumulatorAndFlagRegisterSet {
+        return accumulatorAndFlagRegisterSets[accumulatorAndFlagRegisterSetIndex]
+    }
+
+    fun getGeneralPurposeRegisterSet() : GeneralPurposeRegisterSet {
+        return generalPurposeRegisterSets[generalPurposeRegisterSetIndex]
+    }
+}
+
+/**
+ * The Accumulator holds the results of 8-bit arithmetic or logical operations while the Flag Register indicates
+ * specific conditions for 8-bit or 16-bit operations, such as indicating whether or not the result of an operation
+ * is equal to 0
+ */
+data class AccumulatorAndFlagRegisterSet(var accumulator: UByte = 0u, var flags: UByte = 0u)
+
+/**
+ * 8 bit General purpose registers
+ * Can be combined to form 16 bit registers in this configuration:
+ * BC, DE, and HL
+ */
+data class GeneralPurposeRegisterSet(var registerB: UByte = 0u, var registerC: UByte = 0u, var registerD: UByte = 0u,
+                                     var registerE: UByte = 0u, var registerH: UByte = 0u, var registerL: UByte = 0u)

--- a/src/main/kotlin/com/leeturner/spektrum/cpu/Registers.kt
+++ b/src/main/kotlin/com/leeturner/spektrum/cpu/Registers.kt
@@ -12,7 +12,6 @@ data class Registers(
     var indexY: UShort = 0u,
     var interruptPageAddress: UByte = 0u,
     var memoryRefresh: UByte = 0u,
-
     /**
      * The CPU can switch between two sets of these registers using exchange instructions.
      * There is a separate exchange instruction for the accumulatorAndFlag registers and the generalPurpose registers
@@ -20,10 +19,9 @@ data class Registers(
     private var accumulatorAndFlagRegisterSetIndex: Int = 0,
     private val accumulatorAndFlagRegisterSets: List<AccumulatorAndFlagRegisterSet> =
         listOf(AccumulatorAndFlagRegisterSet(), AccumulatorAndFlagRegisterSet()),
-
     private var generalPurposeRegisterSetIndex: Int = 0,
     private val generalPurposeRegisterSets: List<GeneralPurposeRegisterSet> =
-        listOf(GeneralPurposeRegisterSet(), GeneralPurposeRegisterSet())
+        listOf(GeneralPurposeRegisterSet(), GeneralPurposeRegisterSet()),
 ) {
     fun flipAccumulatorAndFlagRegisterSet(): AccumulatorAndFlagRegisterSet {
         accumulatorAndFlagRegisterSetIndex++
@@ -39,13 +37,10 @@ data class Registers(
         return generalPurposeRegisterSets[generalPurposeRegisterSetIndex]
     }
 
-    fun getAccumulatorAndFlagRegisterSet() : AccumulatorAndFlagRegisterSet {
-        return accumulatorAndFlagRegisterSets[accumulatorAndFlagRegisterSetIndex]
-    }
+    fun getAccumulatorAndFlagRegisterSet(): AccumulatorAndFlagRegisterSet =
+        accumulatorAndFlagRegisterSets[accumulatorAndFlagRegisterSetIndex]
 
-    fun getGeneralPurposeRegisterSet() : GeneralPurposeRegisterSet {
-        return generalPurposeRegisterSets[generalPurposeRegisterSetIndex]
-    }
+    fun getGeneralPurposeRegisterSet(): GeneralPurposeRegisterSet = generalPurposeRegisterSets[generalPurposeRegisterSetIndex]
 }
 
 /**
@@ -53,12 +48,21 @@ data class Registers(
  * specific conditions for 8-bit or 16-bit operations, such as indicating whether or not the result of an operation
  * is equal to 0
  */
-data class AccumulatorAndFlagRegisterSet(var accumulator: UByte = 0u, var flags: UByte = 0u)
+data class AccumulatorAndFlagRegisterSet(
+    var accumulator: UByte = 0u,
+    var flags: UByte = 0u,
+)
 
 /**
  * 8 bit General purpose registers
  * Can be combined to form 16 bit registers in this configuration:
  * BC, DE, and HL
  */
-data class GeneralPurposeRegisterSet(var registerB: UByte = 0u, var registerC: UByte = 0u, var registerD: UByte = 0u,
-                                     var registerE: UByte = 0u, var registerH: UByte = 0u, var registerL: UByte = 0u)
+data class GeneralPurposeRegisterSet(
+    var registerB: UByte = 0u,
+    var registerC: UByte = 0u,
+    var registerD: UByte = 0u,
+    var registerE: UByte = 0u,
+    var registerH: UByte = 0u,
+    var registerL: UByte = 0u,
+)

--- a/src/test/kotlin/com/leeturner/spektrum/cpu/RegistersTest.kt
+++ b/src/test/kotlin/com/leeturner/spektrum/cpu/RegistersTest.kt
@@ -1,0 +1,177 @@
+package com.leeturner.spektrum.cpu
+
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class RegistersTest {
+
+    @Test
+    fun initialState() {
+        val registers = Registers()
+
+        expectThat(registers) {
+            get { programCounter } isEqualTo 0u
+            get { stackPointer } isEqualTo 0u
+            get { indexX } isEqualTo 0u
+            get { indexY } isEqualTo 0u
+            get { interruptPageAddress } isEqualTo 0u
+            get { memoryRefresh } isEqualTo 0u
+        }
+
+        expectThat(registers.getGeneralPurposeRegisterSet()) {
+            get { registerB } isEqualTo 0u
+            get { registerC } isEqualTo 0u
+            get { registerD } isEqualTo 0u
+            get { registerE } isEqualTo 0u
+            get { registerH } isEqualTo 0u
+            get { registerL } isEqualTo 0u
+        }
+
+        expectThat(registers.getAccumulatorAndFlagRegisterSet()) {
+            get { accumulator } isEqualTo 0u
+            get { flags } isEqualTo 0u
+        }
+
+        registers.flipAccumulatorAndFlagRegisterSet()
+        registers.flipGeneralPurposeRegisterSet()
+
+        expectThat(registers.getGeneralPurposeRegisterSet()) {
+            get { registerB } isEqualTo 0u
+            get { registerC } isEqualTo 0u
+            get { registerD } isEqualTo 0u
+            get { registerE } isEqualTo 0u
+            get { registerH } isEqualTo 0u
+            get { registerL } isEqualTo 0u
+        }
+
+        expectThat(registers.getAccumulatorAndFlagRegisterSet()) {
+            get { accumulator } isEqualTo 0u
+            get { flags } isEqualTo 0u
+        }
+    }
+
+    @Test
+    fun flipAccumulatorAndFlagRegisters() {
+        val registers = Registers()
+
+        // Initially no change from default zeroes
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 0u, 0u)
+
+        // Change in values should be reflected when the getter is called
+        var accumulatorAndFlagRegisterSet = registers.getAccumulatorAndFlagRegisterSet()
+        accumulatorAndFlagRegisterSet.accumulator = 1u
+        accumulatorAndFlagRegisterSet.flags = 2u
+
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 1u, 2u)
+
+        registers.flipAccumulatorAndFlagRegisterSet()
+
+        // Now we should have flipped to the other set, which haven't been changed from zeroes.
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 0u, 0u)
+
+        // Change this second set too and test it
+        accumulatorAndFlagRegisterSet = registers.getAccumulatorAndFlagRegisterSet()
+        accumulatorAndFlagRegisterSet.accumulator = 3u
+        accumulatorAndFlagRegisterSet.flags = 4u
+
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 3u, 4u)
+
+        // Now flip back and forth to check all is working
+        registers.flipAccumulatorAndFlagRegisterSet()
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 1u, 2u)
+
+        registers.flipAccumulatorAndFlagRegisterSet()
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 3u, 4u)
+
+        registers.flipAccumulatorAndFlagRegisterSet()
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 1u, 2u)
+
+        registers.flipAccumulatorAndFlagRegisterSet()
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.getAccumulatorAndFlagRegisterSet(), 3u, 4u)
+
+        // Now we check that the return value of the flip method works in the same way
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.flipAccumulatorAndFlagRegisterSet(), 1u, 2u)
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.flipAccumulatorAndFlagRegisterSet(), 3u, 4u)
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.flipAccumulatorAndFlagRegisterSet(), 1u, 2u)
+        expectCurrentAccumulatorAndFlagRegisterStates(registers.flipAccumulatorAndFlagRegisterSet(), 3u, 4u)
+
+    }
+
+    @Test
+    fun flipGeneralPurposeRegisters() {
+        val registers = Registers()
+
+        // Initially no change from default zeroes
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 0u, 0u, 0u, 0u, 0u, 0u)
+
+        // Change in values should be reflected when the getter is called
+        var generalPurposeRegisterSet = registers.getGeneralPurposeRegisterSet()
+        generalPurposeRegisterSet.registerB = 1u
+        generalPurposeRegisterSet.registerC = 2u
+        generalPurposeRegisterSet.registerD = 3u
+        generalPurposeRegisterSet.registerE = 4u
+        generalPurposeRegisterSet.registerH = 5u
+        generalPurposeRegisterSet.registerL = 6u
+
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 1u, 2u, 3u, 4u, 5u, 6u)
+
+        registers.flipGeneralPurposeRegisterSet()
+
+        // Now we should have flipped to the other set, which haven't been changed from zeroes.
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 0u, 0u, 0u, 0u, 0u, 0u)
+
+        // Change this second set too and test it
+        generalPurposeRegisterSet = registers.getGeneralPurposeRegisterSet()
+        generalPurposeRegisterSet.registerB = 7u
+        generalPurposeRegisterSet.registerC = 8u
+        generalPurposeRegisterSet.registerD = 9u
+        generalPurposeRegisterSet.registerE = 10u
+        generalPurposeRegisterSet.registerH = 11u
+        generalPurposeRegisterSet.registerL = 12u
+
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 7u, 8u, 9u, 10u, 11u, 12u)
+
+        // Now flip back and forth to check all is working
+        registers.flipGeneralPurposeRegisterSet()
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 1u, 2u, 3u, 4u, 5u, 6u)
+
+        registers.flipGeneralPurposeRegisterSet()
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 7u, 8u, 9u, 10u, 11u, 12u)
+
+        registers.flipGeneralPurposeRegisterSet()
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 1u, 2u, 3u, 4u, 5u, 6u)
+
+        registers.flipGeneralPurposeRegisterSet()
+        expectGeneralPurposeRegisterStates(registers.getGeneralPurposeRegisterSet(), 7u, 8u, 9u, 10u, 11u, 12u)
+
+        // Now we check that the return value of the flip method works in the same way
+        expectGeneralPurposeRegisterStates(registers.flipGeneralPurposeRegisterSet(), 1u, 2u, 3u, 4u, 5u, 6u)
+        expectGeneralPurposeRegisterStates(registers.flipGeneralPurposeRegisterSet(), 7u, 8u, 9u, 10u, 11u, 12u)
+        expectGeneralPurposeRegisterStates(registers.flipGeneralPurposeRegisterSet(), 1u, 2u, 3u, 4u, 5u, 6u)
+        expectGeneralPurposeRegisterStates(registers.flipGeneralPurposeRegisterSet(), 7u, 8u, 9u, 10u, 11u, 12u)
+    }
+
+    private fun expectCurrentAccumulatorAndFlagRegisterStates(registerSet: AccumulatorAndFlagRegisterSet,
+                                                              expectedAccumulatorState: UByte,
+                                                              expectedFlagsState: UByte) {
+        expectThat(registerSet) {
+            get { accumulator } isEqualTo expectedAccumulatorState
+            get { flags } isEqualTo expectedFlagsState
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun expectGeneralPurposeRegisterStates(registerSet: GeneralPurposeRegisterSet, expectedBState: UByte,
+                                                   expectedCState: UByte, expectedDState: UByte, expectedEState: UByte,
+                                                   expectedHState: UByte, expectedLState: UByte) {
+        expectThat(registerSet) {
+            get { registerB } isEqualTo expectedBState
+            get { registerC } isEqualTo expectedCState
+            get { registerD } isEqualTo expectedDState
+            get { registerE } isEqualTo expectedEState
+            get { registerH } isEqualTo expectedHState
+            get { registerL } isEqualTo expectedLState
+        }
+    }
+}

--- a/src/test/kotlin/com/leeturner/spektrum/cpu/RegistersTest.kt
+++ b/src/test/kotlin/com/leeturner/spektrum/cpu/RegistersTest.kt
@@ -5,7 +5,6 @@ import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
 class RegistersTest {
-
     @Test
     fun initialState() {
         val registers = Registers()
@@ -95,7 +94,6 @@ class RegistersTest {
         expectCurrentAccumulatorAndFlagRegisterStates(registers.flipAccumulatorAndFlagRegisterSet(), 3u, 4u)
         expectCurrentAccumulatorAndFlagRegisterStates(registers.flipAccumulatorAndFlagRegisterSet(), 1u, 2u)
         expectCurrentAccumulatorAndFlagRegisterStates(registers.flipAccumulatorAndFlagRegisterSet(), 3u, 4u)
-
     }
 
     @Test
@@ -152,9 +150,11 @@ class RegistersTest {
         expectGeneralPurposeRegisterStates(registers.flipGeneralPurposeRegisterSet(), 7u, 8u, 9u, 10u, 11u, 12u)
     }
 
-    private fun expectCurrentAccumulatorAndFlagRegisterStates(registerSet: AccumulatorAndFlagRegisterSet,
-                                                              expectedAccumulatorState: UByte,
-                                                              expectedFlagsState: UByte) {
+    private fun expectCurrentAccumulatorAndFlagRegisterStates(
+        registerSet: AccumulatorAndFlagRegisterSet,
+        expectedAccumulatorState: UByte,
+        expectedFlagsState: UByte,
+    ) {
         expectThat(registerSet) {
             get { accumulator } isEqualTo expectedAccumulatorState
             get { flags } isEqualTo expectedFlagsState
@@ -162,9 +162,15 @@ class RegistersTest {
     }
 
     @Suppress("LongParameterList")
-    private fun expectGeneralPurposeRegisterStates(registerSet: GeneralPurposeRegisterSet, expectedBState: UByte,
-                                                   expectedCState: UByte, expectedDState: UByte, expectedEState: UByte,
-                                                   expectedHState: UByte, expectedLState: UByte) {
+    private fun expectGeneralPurposeRegisterStates(
+        registerSet: GeneralPurposeRegisterSet,
+        expectedBState: UByte,
+        expectedCState: UByte,
+        expectedDState: UByte,
+        expectedEState: UByte,
+        expectedHState: UByte,
+        expectedLState: UByte,
+    ) {
         expectThat(registerSet) {
             get { registerB } isEqualTo expectedBState
             get { registerC } isEqualTo expectedCState


### PR DESCRIPTION
Adds support for the Z80 register sets based on the CPU Register section of the document starting on page 16.

The processor has the cool functionality of being able to switch between different sets of registers on demand via a couple of CPU instructions. This has been added with the ability to switch between sets via the appropriate method call.
